### PR TITLE
Changed / to or in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ logger.info('hello to file');
 //=> writes a log message to development.log
 ```
 New log messages are appended to the file.
-Currently, there is no strategy/policy for handling large log files. 
+Currently, there is no strategy or policy for handling large log files. 
 
 ### Logging
 


### PR DESCRIPTION
# Description

As part of the CSWE lecture I changed a "/" to the word "or" in the readme file.

Fixes # (issue)

## Type of change

